### PR TITLE
Add Legend of Elya — 819K-param LLM on Nintendo 64

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ For training, GPU memory requirements are typically higher. Using techniques lik
 
 ## Community Projects
 
+- [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - World's first LLM on Nintendo 64. 819K-parameter nano-GPT transformer running live inference on the MIPS R4300i CPU at 60 tok/s. Pushes small language models to the extreme — a Zelda-style dungeon crawler with AI NPCs on 1996 console hardware (4 MB RAM, 93.75 MHz).
 - [Add your awesome community projects here!]
 
 


### PR DESCRIPTION
## Summary

Adds [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) to the Community Projects section.

This is the world's first LLM running on Nintendo 64 hardware — an 819K-parameter nano-GPT transformer running live inference on the MIPS R4300i FPU at 60 tokens/second. It demonstrates small language models taken to the absolute extreme: a playable Zelda-style dungeon crawler with AI NPCs on 1996 console hardware with just 4 MB of RAM at 93.75 MHz.

- Custom 4-layer transformer trained from scratch
- Uses N64's RSP vector unit for matrix multiplication
- Full source code and .z64 ROM available
- Built with libdragon SDK

A unique example of what small language models can achieve on extremely constrained hardware.